### PR TITLE
allow export of existing filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage: gmailfilters <command>
 Flags:
 
   -d, --debug       enable debug logging (default: false)
+  -e, --export      export existing filters (default: false)
   -f, --creds-file  Gmail credential file (or env var GMAIL_CREDENTIAL_FILE) (default: <none>)
 
 Commands:

--- a/filter.go
+++ b/filter.go
@@ -205,7 +205,7 @@ func getExistingFilters() ([]filter, error) {
 
 	var filters []filter
 
-	for _, gmailFilter:= range gmailFilters.Filter {
+	for _, gmailFilter := range gmailFilters.Filter {
 		var f filter
 
 		if gmailFilter.Criteria.Query > "" {

--- a/filter.go
+++ b/filter.go
@@ -198,14 +198,14 @@ func getExistingFilters() ([]filter, error) {
 		return nil, err
 	}
 
-	labels, err := getLabelMapOnId()
+	labels, err := getLabelMapOnID()
 	if err != nil {
 		return nil, err
 	}
 
 	var filters []filter
 
-	for _, gmailFilter:= range gmailFilters.Filter {
+	for _, gmailFilter := range gmailFilters.Filter {
 		var f filter
 
 		if gmailFilter.Criteria.Query > "" {
@@ -216,11 +216,11 @@ func getExistingFilters() ([]filter, error) {
 			}
 
 			if len(gmailFilter.Action.AddLabelIds) > 0 {
-				labelId := gmailFilter.Action.AddLabelIds[0]
-				if labelId == "TRASH" {
+				labelID := gmailFilter.Action.AddLabelIds[0]
+				if labelID == "TRASH" {
 					f.Delete = true
 				} else {
-					labelName, ok := labels[labelId]
+					labelName, ok := labels[labelID]
 					if ok {
 						f.Label = labelName
 					}
@@ -228,10 +228,10 @@ func getExistingFilters() ([]filter, error) {
 			}
 
 			if len(gmailFilter.Action.RemoveLabelIds) > 0 {
-				for _, labelId := range gmailFilter.Action.RemoveLabelIds {
-					if labelId == "UNREAD" {
+				for _, labelID := range gmailFilter.Action.RemoveLabelIds {
+					if labelID == "UNREAD" {
 						f.Read = true
-					} else if labelId == "INBOX" {
+					} else if labelID == "INBOX" {
 						if gmailFilter.Criteria.NegatedQuery == "to:me" {
 							f.ArchiveUnlessToMe = true
 						} else {

--- a/filter.go
+++ b/filter.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -142,6 +144,36 @@ func decodeFile(file string) ([]filter, error) {
 	return ff.Filter, nil
 }
 
+func exportExistingFilters(file string) error {
+	fmt.Print("exporting existing filters...\n")
+
+	filters, err := getExistingFilters()
+	if err != nil {
+		return fmt.Errorf("error downloading existing filters: %v", err)
+	}
+
+	var ff filterfile
+	for _, f := range filters {
+		// We could get duplicate filters, so it's best to remove them.
+		existingFilter := findExistingFilter(ff.Filter, f.Query)
+
+		// Since we can't return nil on a struct or compary it to something empty,
+		// check if the query exists. If not then consider it not found.
+		if existingFilter.Query != "" {
+			// Duplicate filters can only exist if the ArchiveUnlessToMe is set.
+			// So we can simply reset everything and just set the ArchiveUnlessToMe flag to true.
+			existingFilter.Archive = false
+			existingFilter.Delete = false
+			existingFilter.ToMe = false
+			existingFilter.ArchiveUnlessToMe = true
+		} else {
+			ff.Filter = append(ff.Filter, f)
+		}
+	}
+
+	return writeFiltersToFile(ff, file)
+}
+
 func deleteExistingFilters() error {
 	// Get current filters for the user.
 	l, err := api.Users.Settings.Filters.List(gmailUser).Do()
@@ -158,4 +190,89 @@ func deleteExistingFilters() error {
 	}
 
 	return nil
+}
+
+func getExistingFilters() ([]filter, error) {
+	gmailFilters, err := api.Users.Settings.Filters.List(gmailUser).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	labels, err := getLabelMapOnId()
+	if err != nil {
+		return nil, err
+	}
+
+	var filters []filter
+
+	for _, gmailFilter:= range gmailFilters.Filter {
+		var f filter
+
+		if gmailFilter.Criteria.Query > "" {
+			f.Query = gmailFilter.Criteria.Query
+
+			if gmailFilter.Criteria.To == "me" {
+				f.ToMe = true
+			}
+
+			if len(gmailFilter.Action.AddLabelIds) > 0 {
+				labelId := gmailFilter.Action.AddLabelIds[0]
+				if labelId == "TRASH" {
+					f.Delete = true
+				} else {
+					labelName, ok := labels[labelId]
+					if ok {
+						f.Label = labelName
+					}
+				}
+			}
+
+			if len(gmailFilter.Action.RemoveLabelIds) > 0 {
+				for _, labelId := range gmailFilter.Action.RemoveLabelIds {
+					if labelId == "UNREAD" {
+						f.Read = true
+					} else if labelId == "INBOX" {
+						if gmailFilter.Criteria.NegatedQuery == "to:me" {
+							f.ArchiveUnlessToMe = true
+						} else {
+							f.Archive = true
+						}
+					}
+				}
+			}
+		}
+
+		filters = append(filters, f)
+	}
+
+	return filters, nil
+}
+
+func writeFiltersToFile(ff filterfile, file string) error {
+	exportFile, err := os.Create(file)
+	if err != nil {
+		return fmt.Errorf("error exporting filters: %v", err)
+	}
+
+	writer := bufio.NewWriter(exportFile)
+	encoder := toml.NewEncoder(writer)
+	encoder.Indent = ""
+
+	if err := encoder.Encode(ff); err != nil {
+		return fmt.Errorf("error writing file: %v", err)
+	}
+
+	fmt.Printf("Exported %d filters\n", len(ff.Filter))
+
+	return nil
+}
+
+func findExistingFilter(filters []filter, query string) filter {
+	for _, f := range filters {
+		if f.Query == query {
+			return f
+		}
+	}
+
+	return filter{}
 }

--- a/labels.go
+++ b/labels.go
@@ -25,6 +25,21 @@ func getLabelMap() (labelMap, error) {
 	return labels, nil
 }
 
+func getLabelMapOnId() (labelMap, error) {
+	// Get the labels for the user and map its name to its ID.
+	l, err := api.Users.Labels.List(gmailUser).Do()
+	if err != nil {
+		return nil, fmt.Errorf("listing labels failed: %v", err)
+	}
+
+	labels := labelMap{}
+	for _, label := range l.Labels {
+		labels[label.Id] = label.Name
+	}
+
+	return labels, nil
+}
+
 func (m *labelMap) createLabelIfDoesNotExist(name string) (string, error) {
 	// De reference the pointer so we can index.
 	labels := *m

--- a/labels.go
+++ b/labels.go
@@ -25,7 +25,7 @@ func getLabelMap() (labelMap, error) {
 	return labels, nil
 }
 
-func getLabelMapOnId() (labelMap, error) {
+func getLabelMapOnID() (labelMap, error) {
 	// Get the labels for the user and map its name to its ID.
 	l, err := api.Users.Labels.List(gmailUser).Do()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ var (
 	api *gmail.Service
 
 	debug bool
+
+	export bool
 )
 
 func main() {
@@ -43,6 +45,9 @@ func main() {
 	p.FlagSet = flag.NewFlagSet("gmailfilters", flag.ExitOnError)
 	p.FlagSet.BoolVar(&debug, "d", false, "enable debug logging")
 	p.FlagSet.BoolVar(&debug, "debug", false, "enable debug logging")
+
+	p.FlagSet.BoolVar(&export, "e", false, "export existing filters")
+	p.FlagSet.BoolVar(&export, "export", false, "export existing filters")
 
 	p.FlagSet.StringVar(&credsFile, "creds-file", os.Getenv("GMAIL_CREDENTIAL_FILE"), "Gmail credential file (or env var GMAIL_CREDENTIAL_FILE)")
 	p.FlagSet.StringVar(&credsFile, "f", os.Getenv("GMAIL_CREDENTIAL_FILE"), "Gmail credential file (or env var GMAIL_CREDENTIAL_FILE)")
@@ -109,6 +114,10 @@ func main() {
 				os.Exit(0)
 			}
 		}()
+
+		if export {
+			return exportExistingFilters(args[0])
+		}
 
 		labels, err := getLabelMap()
 		if err != nil {


### PR DESCRIPTION
This pull request adds rudimentary support for exporting the current set of Gmail filters, so you are not forced to start from a blank file.

Basic usage is the same as importing the filters, with the addition of the `-e` flag.

```
$ gmailfilters -e -f credentials.json filters.toml
```

A few things to note:
* The `QueryOr` is a bit too complex to export, so everything is exported as a `Query`. Take for example the `(from:(-me) {filename:vcs filename:ics} has:attachment) OR (subject:(\"invitation\" OR \"accepted\" OR \"tentatively accepted\" OR \"rejected\" OR \"updated\" OR \"canceled event\" OR \"declined\") when where calendar who organizer)` query. There are multiple `OR` statements within another `OR` which should not be divided. So a simple `strings.split` won't do the trick, but more complex logic is needed to determine whether or not this should be split, or be kept as a single statement. It's doable, but given that it's almost new year's eve I didn't really have the time nor the desire to do so today I went for the quick solution. Since the `QueryOr` parameter is syntactic sugar for a regular `Query` this shouldn't cause any problems.
* Every property of the `Filter` struct is exported, so the exported file is larger than the sample input file. Also, the property names start with an uppercase, simply because I can't seem to configure this in the toml encoder configuration. Doesn't cause a problem though.
* There's only one check for duplicate filters when exporting, and that's for the `ArchiveUnlessToMe` and it simply does it on the query string. As input, the `ArchiveUnlessToMe` creates two filters, but the export should convert this into one filter, or you will get a duplicate filter error when trying to import an exported file. There might be other scenario's were duplicate filters are created to achieve a single thing, but this should be enough to cover the current import implementation.