### PR TITLE
export: ignore filters with empty action

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -213,6 +213,10 @@ func getExistingFilters() ([]filter, error) {
 	for _, gmailFilter := range gmailFilters.Filter {
 		var f filter
 
+		if gmailFilter.Action == nil {
+			continue
+		}
+
 		if gmailFilter.Criteria.Query > "" {
 			f.Query = gmailFilter.Criteria.Query
 


### PR DESCRIPTION
I must have created a filter with a label, then deleted the label, and
the filter was left with no action. Handle this case to prevent a crash
at when Action is nil and dereferenced.

Signed-off-by: Anisse Astier <anisse@astier.eu>