### PR TITLE
Handle Filters.List response having only from: criteria

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -212,14 +212,20 @@ func getExistingFilters() ([]filter, error) {
 
 	for _, gmailFilter := range gmailFilters.Filter {
 		var f filter
-
+		var isFilterValid bool
+		isFilterValid = false
 		if gmailFilter.Criteria.Query > "" {
 			f.Query = gmailFilter.Criteria.Query
 
 			if gmailFilter.Criteria.To == "me" {
 				f.ToMe = true
 			}
-
+			isFilterValid = true
+		} else if gmailFilter.Criteria.From > "" {
+			f.Query = "from: " + gmailFilter.Criteria.From
+			isFilterValid = true
+		}
+		if isFilterValid && gmailFilter.Action != nil {
 			if len(gmailFilter.Action.AddLabelIds) > 0 {
 				labelID := gmailFilter.Action.AddLabelIds[0]
 				if labelID == "TRASH" {

--- a/filter.go
+++ b/filter.go
@@ -222,7 +222,7 @@ func getExistingFilters() ([]filter, error) {
 			}
 			isFilterValid = true
 		} else if gmailFilter.Criteria.From > "" {
-			f.Query = "from: " + gmailFilter.Criteria.From
+			f.Query = "from:(" + gmailFilter.Criteria.From + ")"
 			isFilterValid = true
 		}
 		if isFilterValid && gmailFilter.Action != nil {


### PR DESCRIPTION
closes #11

In scenarios where `from:` is the only criteria on a filter, the application skips over the filter properties (it would appear that `gmailFilter.Criteria.Query` does not include `from:` criteria).

This PR probably does not yet address all scenarios where Filter Critera are present, but not accounted for in `gmailFilter.Criteria.Query`