### PR TITLE
Add support for using filters to apply categories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ to:team_mention@noreply.github.com \
 -to:assign@noreply.github.com
 """
 label = "github/team-mention"
+categorize = "updates"
 
 [[filter]]
 query = """

--- a/filter.go
+++ b/filter.go
@@ -33,11 +33,11 @@ type filter struct {
 }
 
 var categoryLabelIDs = map[string]bool{
-	"PERSONAL": true,
-	"SOCIAL": true,
+	"PERSONAL":   true,
+	"SOCIAL":     true,
 	"PROMOTIONS": true,
-	"UPDATES": true,
-	"FORUMS": true,
+	"UPDATES":    true,
+	"FORUMS":     true,
 }
 
 func (f filter) toGmailFilters(labels *labelMap) ([]gmail.Filter, error) {
@@ -77,7 +77,7 @@ func (f filter) toGmailFilters(labels *labelMap) ([]gmail.Filter, error) {
 			}
 			return nil, errors.New("category \"" + category + "\" is not valid; valid categories are " + strings.Join(validCategories, ", "))
 		}
-		action.AddLabelIds = append(action.AddLabelIds, "CATEGORY_" + category)
+		action.AddLabelIds = append(action.AddLabelIds, "CATEGORY_"+category)
 	}
 
 	action.RemoveLabelIds = []string{}

--- a/filter.go
+++ b/filter.go
@@ -28,7 +28,16 @@ type filter struct {
 	ToMe              bool
 	ArchiveUnlessToMe bool
 	Label             string
+	Categorize        string
 	ForwardTo         string
+}
+
+var categoryLabelIDs = map[string]bool{
+	"PERSONAL": true,
+	"SOCIAL": true,
+	"PROMOTIONS": true,
+	"UPDATES": true,
+	"FORUMS": true,
 }
 
 func (f filter) toGmailFilters(labels *labelMap) ([]gmail.Filter, error) {
@@ -57,6 +66,18 @@ func (f filter) toGmailFilters(labels *labelMap) ([]gmail.Filter, error) {
 			return nil, err
 		}
 		action.AddLabelIds = append(action.AddLabelIds, labelID)
+	}
+
+	if len(f.Categorize) > 0 {
+		category := strings.ToUpper(f.Categorize)
+		if _, present := categoryLabelIDs[category]; !present {
+			validCategories := []string{}
+			for validCategory := range categoryLabelIDs {
+				validCategories = append(validCategories, validCategory)
+			}
+			return nil, errors.New("category \"" + category + "\" is not valid; valid categories are " + strings.Join(validCategories, ", "))
+		}
+		action.AddLabelIds = append(action.AddLabelIds, "CATEGORY_" + category)
 	}
 
 	action.RemoveLabelIds = []string{}

--- a/filter_test.go
+++ b/filter_test.go
@@ -106,6 +106,23 @@ func TestFilterToGmailFilters(t *testing.T) {
 				},
 			},
 		},
+		"categorize": {
+			orig: filter{
+				QueryOr: []string{"to:team_mention@noreply.github.com"},
+				Categorize: "updates",
+			},
+			expected: []gmail.Filter{
+				{
+					Action: &gmail.FilterAction{
+						AddLabelIds:    []string{"CATEGORY_UPDATES"},
+						RemoveLabelIds: []string{},
+					},
+					Criteria: &gmail.FilterCriteria{
+						Query: "to:team_mention@noreply.github.com",
+					},
+				},
+			},
+		},
 	}
 
 	labels := &labelMap{

--- a/filter_test.go
+++ b/filter_test.go
@@ -108,7 +108,7 @@ func TestFilterToGmailFilters(t *testing.T) {
 		},
 		"categorize": {
 			orig: filter{
-				QueryOr: []string{"to:team_mention@noreply.github.com"},
+				QueryOr:    []string{"to:team_mention@noreply.github.com"},
 				Categorize: "updates",
 			},
 			expected: []gmail.Filter{


### PR DESCRIPTION
Gmail has a pretty useful feature called categories, which allow showing different pre-defined tabs for different categories of emails in the Gmail web interface, like so.

![image](https://user-images.githubusercontent.com/5584439/75526319-74dbf880-5a09-11ea-9ec6-65d7fa22567b.png)

Different categories can be shown and hidden in the Gmail settings, but the list of possible categories is always fixed. A list of possible categories can be found [here](https://developers.google.com/gmail/api/guides/labels#types_of_labels).

This pull request extends gmailfilters to be able to create filters that apply categories to emails based on custom criteria. This is done with an extra `categorize` property on the filter, which can be set to any of the possible categories ("PERSONAL", "SOCIAL", "PROMOTIONS", "UPDATES" or "FORUMS"), or a differently-cased variant.

---

Thanks for making this awesome tool; it makes managing my filters way easier!